### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/docharly/2cd357dd-aef3-4d09-80c6-4e19f6ba1e19/e5ad2281-6b4a-47e5-bb82-0e04f1e1a609/_apis/work/boardbadge/6535baa9-4d12-4a83-818f-f1e38afa2be1)](https://dev.azure.com/docharly/2cd357dd-aef3-4d09-80c6-4e19f6ba1e19/_boards/board/t/e5ad2281-6b4a-47e5-bb82-0e04f1e1a609/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/docharly/2cd357dd-aef3-4d09-80c6-4e19f6ba1e19/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.